### PR TITLE
Repro for ServiceControl Issue 1596

### DIFF
--- a/Raven.Tests/Storage/Attachments.cs
+++ b/Raven.Tests/Storage/Attachments.cs
@@ -39,9 +39,9 @@ namespace Raven.Tests.Storage
         {
             using (var store = NewDocumentStore())
             {
-                await store.AsyncDatabaseCommands.PutAttachmentAsync("Ayende", null, new MemoryStream(new byte[] { 1, 2, 3 }), new RavenJObject());
+                await store.AsyncDatabaseCommands.PutAttachmentAsync("messagebodies/3f0240a7-9b2e-4e2a-ab39-6114932adad1\\2055783", null, new MemoryStream(new byte[] { 1, 2, 3 }), new RavenJObject());
 
-                Attachment attachment = await store.AsyncDatabaseCommands.GetAttachmentAsync("Ayende");
+                Attachment attachment = await store.AsyncDatabaseCommands.GetAttachmentAsync("messagebodies/3f0240a7-9b2e-4e2a-ab39-6114932adad1\\2055783");
                 Assert.Equal(new byte[] {1, 2, 3}, attachment.Data().ReadData());
             }
         }


### PR DESCRIPTION
Reproduction for https://github.com/Particular/ServiceControl/issues/1596

We are not sure why this happens. Are there undocumented limits to the document id size?